### PR TITLE
Better id generation for navigation items

### DIFF
--- a/Navigation/NavigationItem.php
+++ b/Navigation/NavigationItem.php
@@ -442,7 +442,7 @@ class NavigationItem implements \Iterator
             'action' => $this->getAction(),
             'hasSettings' => $this->getHasSettings(),
             'disabled' => $this->getDisabled(),
-            'id' => ($this->getId() != null) ? $this->getId() : uniqid(), //FIXME don't use uniqid()
+            'id' => ($this->getId() != null) ? $this->getId() : substr(sha1(microtime(true).mt_rand(10000,90000)), 27)
         );
 
         if ($this->getHeaderIcon() != null || $this->getHeaderTitle() != null) {


### PR DESCRIPTION
Changed unique id generation method, because uniqid() function doesn't guarantee uniqueness, especially when multiple id are generated in a short timespan.
In my case, for some menu items I was getting the same id for all, and this was probably due to id generation within one microsecond, during which uniqid() produced the same value, being based on microtime() function.